### PR TITLE
Place the Rails pid file in /tmp

### DIFF
--- a/images/foreman/Containerfile
+++ b/images/foreman/Containerfile
@@ -13,7 +13,7 @@ ENV FOREMAN_BIND=0.0.0.0
 ENV RAILS_SERVE_STATIC_FILES=true
 ENV RAILS_ENV=production
 ENV RAILS_LOG_TO_STDOUT=true
-CMD /usr/share/foreman/bin/rails db:migrate && /usr/share/foreman/bin/rails db:seed && /usr/share/foreman/bin/rails server --environment production
+CMD /usr/share/foreman/bin/rails db:migrate && /usr/share/foreman/bin/rails db:seed && /usr/share/foreman/bin/rails server --environment production --pid /tmp/rails.pid
 EXPOSE 3000/tcp
 
 ARG FOREMAN_PLUGINS="foreman-tasks foreman_remote_execution katello foreman_google foreman_azure_rm foreman_kubevirt"


### PR DESCRIPTION
To be able to share data between the Foreman container and Dynflow workers, foremanctl mounts `/var/run/foreman` as a persistent volume [1]. However, that means that if the system crashes for some reason, the pid file Rails writes there remains and the server refuses to start with

    A server is already running. Check /usr/share/foreman/tmp/pids/server.pid.

It's not possible to disable this in Rails 7.0 (7.2+ does it atomatically [2]), but we can configure a path that is guaranteed to be cleaned up when the container starts freshly: /tmp

[1] https://github.com/theforeman/foremanctl/commit/82e541568cb65bb64a9ac0bae41426b3b16b680a
[2] https://github.com/rails/rails/commit/482330d156ebde147992c1973b4c572cee89737e