### PR TITLE
Switch FOREMAN_PLUGINS to the short names

### DIFF
--- a/images/foreman/Containerfile
+++ b/images/foreman/Containerfile
@@ -16,11 +16,11 @@ ENV RAILS_LOG_TO_STDOUT=true
 CMD /usr/share/foreman/bin/rails db:migrate && /usr/share/foreman/bin/rails db:seed && /usr/share/foreman/bin/rails server --environment production --pid /tmp/rails.pid
 EXPOSE 3000/tcp
 
-ARG FOREMAN_PLUGINS="foreman-tasks foreman_remote_execution katello foreman_google foreman_azure_rm foreman_kubevirt foreman_rh_cloud"
+ARG FOREMAN_PLUGINS="tasks remote_execution katello google azure_rm kubevirt rh_cloud"
 
 RUN set -eu; for PLUGIN in ${FOREMAN_PLUGINS}; do \
     echo $PLUGIN; \
-    dnf install --nodocs -y "rubygem($PLUGIN)"; \
+    dnf install --nodocs -y "foreman-plugin-$PLUGIN"; \
     echo "gem '$PLUGIN' if ENV.fetch('FOREMAN_ENABLED_PLUGINS', '').split.include?('$PLUGIN') || ENV.fetch('FOREMAN_ENABLED_PLUGINS', nil).nil?" > /usr/share/foreman/bundler.d/$PLUGIN.rb; \
   done; dnf clean all
 


### PR DESCRIPTION
This relies on the `foreman-plugin-$PLUGIN` Provides statement that the packages should all have.