### PR TITLE
Install which for rubyimpi to work

### DIFF
--- a/images/foreman-proxy/Containerfile
+++ b/images/foreman-proxy/Containerfile
@@ -4,7 +4,7 @@ ARG FOREMAN_VERSION=nightly
 ARG KATELLO_VERSION=nightly
 ARG FOREMAN_PROXY_PLUGINS="remote_execution_ssh ansible"
 
-RUN dnf upgrade -y && dnf install --nodocs -y https://yum.theforeman.org/releases/${FOREMAN_VERSION}/el9/x86_64/foreman-release.rpm https://yum.theforeman.org/katello/${KATELLO_VERSION}/katello/el9/x86_64/katello-repos-latest.rpm && dnf install --nodocs foreman-proxy openssh-clients openssh -y && dnf clean all
+RUN dnf upgrade -y && dnf install --nodocs -y https://yum.theforeman.org/releases/${FOREMAN_VERSION}/el9/x86_64/foreman-release.rpm https://yum.theforeman.org/katello/${KATELLO_VERSION}/katello/el9/x86_64/katello-repos-latest.rpm && dnf install --nodocs foreman-proxy openssh-clients openssh which -y && dnf clean all
 
 RUN set -eu; for PLUGIN in ${FOREMAN_PROXY_PLUGINS}; do \
     echo $PLUGIN; \


### PR DESCRIPTION
without `which` the rubyipmi fails at https://github.com/logicminds/rubyipmi/blob/main/lib/rubyipmi.rb#L155 with 
Error details for No such file or directory - which: <Errno::ENOENT>: No such file or directory - which