### PR TITLE
install freeipmi

### DIFF
--- a/images/foreman-proxy/Containerfile
+++ b/images/foreman-proxy/Containerfile
@@ -4,7 +4,7 @@ ARG FOREMAN_VERSION=nightly
 ARG KATELLO_VERSION=nightly
 ARG FOREMAN_PROXY_PLUGINS="remote_execution_ssh ansible"
 
-RUN dnf upgrade -y && dnf install --nodocs -y https://yum.theforeman.org/releases/${FOREMAN_VERSION}/el9/x86_64/foreman-release.rpm https://yum.theforeman.org/katello/${KATELLO_VERSION}/katello/el9/x86_64/katello-repos-latest.rpm && dnf install --nodocs foreman-proxy openssh-clients openssh -y && dnf clean all
+RUN dnf upgrade -y && dnf install --nodocs -y https://yum.theforeman.org/releases/${FOREMAN_VERSION}/el9/x86_64/foreman-release.rpm https://yum.theforeman.org/katello/${KATELLO_VERSION}/katello/el9/x86_64/katello-repos-latest.rpm && dnf install --nodocs foreman-proxy openssh-clients openssh freeipmi -y && dnf clean all
 
 RUN set -eu; for PLUGIN in ${FOREMAN_PROXY_PLUGINS}; do \
     echo $PLUGIN; \


### PR DESCRIPTION
ipmitool package gets installed in proxy container as its [required](https://github.com/theforeman/foreman-packaging/blob/rpm/develop/packages/foreman/rubygem-rubyipmi/rubygem-rubyipmi.spec#L22C11-L22C19) by rubyipmi gem, but as freeipmi is not in that list it won't get installed out of the box. 