### PR TITLE
Remove encryption_key.rb to ensure no static keys can be used

### DIFF
--- a/images/foreman/Containerfile
+++ b/images/foreman/Containerfile
@@ -24,4 +24,6 @@ RUN set -eu; for PLUGIN in ${FOREMAN_PLUGINS}; do \
     echo "gem '$PLUGIN' if ENV.fetch('FOREMAN_ENABLED_PLUGINS', '').split.include?('$PLUGIN') || ENV.fetch('FOREMAN_ENABLED_PLUGINS', nil).nil?" > /usr/share/foreman/bundler.d/$PLUGIN.rb; \
   done; dnf clean all
 
+RUN rm /usr/share/foreman/config/initializers/encryption_key.rb /etc/foreman/encryption_key.rb
+
 USER foreman


### PR DESCRIPTION
This is generated in the postinstall by the RPM, but should not be used in container deployments, as those need to generate an own, unique, key