### PR TITLE
Install container_gateway gem

### DIFF
--- a/images/foreman-proxy/Containerfile
+++ b/images/foreman-proxy/Containerfile
@@ -2,7 +2,7 @@ FROM quay.io/centos/centos:stream10
 
 ARG FOREMAN_VERSION=nightly
 ARG KATELLO_VERSION=nightly
-ARG FOREMAN_PROXY_PLUGINS="remote_execution_ssh ansible"
+ARG FOREMAN_PROXY_PLUGINS="remote_execution_ssh ansible container_gateway"
 ARG FOREMAN_PROXY_UID=991
 ARG FOREMAN_PROXY_GID=991
 


### PR DESCRIPTION
Prepares for the future when foremanctl enables and configures smart_proxy_container_gateway.