### PR TITLE
Add foreman_theme_satellite to foreman image plugins

### DIFF
--- a/images/foreman/Containerfile
+++ b/images/foreman/Containerfile
@@ -16,7 +16,7 @@ ENV RAILS_LOG_TO_STDOUT=true
 CMD /usr/share/foreman/bin/rails db:migrate && /usr/share/foreman/bin/rails db:seed && /usr/share/foreman/bin/rails server --environment production --pid /tmp/rails.pid
 EXPOSE 3000/tcp
 
-ARG FOREMAN_PLUGINS="foreman-tasks foreman_remote_execution katello foreman_google foreman_azure_rm foreman_kubevirt foreman_rh_cloud foreman_ansible"
+ARG FOREMAN_PLUGINS="foreman-tasks foreman_remote_execution katello foreman_google foreman_azure_rm foreman_kubevirt foreman_rh_cloud foreman_ansible foreman_theme_satellite"
 
 RUN set -eu; for PLUGIN in ${FOREMAN_PLUGINS}; do \
     echo $PLUGIN; \


### PR DESCRIPTION
## Summary

- Adds `foreman_theme_satellite` to `FOREMAN_PLUGINS` in the foreman container image
- The satellite flavor in foremanctl (theforeman/foremanctl#628) uses the `theme-satellite` feature, which requires this gem to be available in the image
- The plugin is conditionally enabled at runtime via `FOREMAN_ENABLED_PLUGINS`, same as all other plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)