### PR TITLE
Static UID/GID

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -27,6 +27,19 @@ jobs:
       - uses: actions/checkout@v7
       - name: Build ${{ matrix.container }} container
         run: make build PROJECT=${{ matrix.container }}
+      - name: Verify static UID/GID
+        run: |
+          if [ "${{ matrix.container }}" = "foreman" ]; then
+            uid=$(podman run --rm quay.io/foreman/${{ matrix.container }}:nightly id -u foreman)
+            gid=$(podman run --rm quay.io/foreman/${{ matrix.container }}:nightly id -g foreman)
+            echo "foreman uid=$uid gid=$gid"
+            [ "$uid" = "994" ] && [ "$gid" = "994" ]
+          elif [ "${{ matrix.container }}" = "foreman-proxy" ]; then
+            uid=$(podman run --rm quay.io/foreman/${{ matrix.container }}:nightly id -u foreman-proxy)
+            gid=$(podman run --rm quay.io/foreman/${{ matrix.container }}:nightly id -g foreman-proxy)
+            echo "foreman-proxy uid=$uid gid=$gid"
+            [ "$uid" = "991" ] && [ "$gid" = "991" ]
+          fi
       - name: Test ${{ matrix.container }} container
         if: matrix.container == 'foreman-proxy'
         run: |

--- a/images/foreman-proxy/Containerfile
+++ b/images/foreman-proxy/Containerfile
@@ -3,6 +3,11 @@ FROM quay.io/centos/centos:stream9
 ARG FOREMAN_VERSION=nightly
 ARG KATELLO_VERSION=nightly
 ARG FOREMAN_PROXY_PLUGINS="remote_execution_ssh ansible"
+ARG FOREMAN_PROXY_UID=991
+ARG FOREMAN_PROXY_GID=991
+
+RUN groupadd -r -g ${FOREMAN_PROXY_GID} foreman-proxy && \
+    useradd -r -g foreman-proxy -u ${FOREMAN_PROXY_UID} -d /usr/share/foreman-proxy -s /sbin/nologin -c "Foreman Proxy user" foreman-proxy
 
 RUN dnf upgrade -y && dnf install --nodocs -y https://yum.theforeman.org/releases/${FOREMAN_VERSION}/el9/x86_64/foreman-release.rpm https://yum.theforeman.org/katello/${KATELLO_VERSION}/katello/el9/x86_64/katello-repos-latest.rpm && dnf install --nodocs foreman-proxy openssh-clients openssh freeipmi bind-utils -y && dnf clean all
 

--- a/images/foreman/Containerfile
+++ b/images/foreman/Containerfile
@@ -2,9 +2,14 @@ FROM quay.io/centos/centos:stream9
 
 ARG FOREMAN_VERSION=nightly
 ARG KATELLO_VERSION=nightly
+ARG FOREMAN_UID=994
+ARG FOREMAN_GID=994
 
 ENV RAILS_ENV=production
 ENV RAILS_LOG_TO_STDOUT=true
+
+RUN groupadd -r -g ${FOREMAN_GID} foreman && \
+    useradd -r -g foreman -u ${FOREMAN_UID} -d /usr/share/foreman -s /sbin/nologin -c "Foreman user" foreman
 
 RUN dnf upgrade -y && dnf install --nodocs -y https://yum.theforeman.org/releases/${FOREMAN_VERSION}/el9/x86_64/foreman-release.rpm https://yum.theforeman.org/katello/${KATELLO_VERSION}/katello/el9/x86_64/katello-repos-latest.rpm && \
     dnf install foreman foreman-postgresql foreman-service foreman-redis foreman-dynflow-sidekiq \


### PR DESCRIPTION
## Summary
Assign static UID/GID for `foreman` (994:994) and `foreman-proxy` (991:991)
by pre-creating the users before RPM installation.
## Problem
The `foreman`([foreman.spec](https://github.com/theforeman/foreman-packaging/blob/rpm/develop/packages/foreman/foreman/foreman.spec#L808-L812)) and `foreman-proxy`([foreman-proxy.spec](https://github.com/theforeman/foreman-packaging/blob/rpm/develop/packages/foreman/foreman-proxy/foreman-proxy.spec#L198-L204)) RPM packages create their service users
in the `%pre` scriptlet using dynamic allocation, which does not result in fixed UID/GID and may cause issues with volume mounts permissions
