### PR TITLE
Add check-non-root-user task to build pipelines

### DIFF
--- a/.tekton/foreman-develop-pull-request.yaml
+++ b/.tekton/foreman-develop-pull-request.yaml
@@ -457,6 +457,26 @@ spec:
         operator: in
         values:
         - "false"
+    - name: check-non-root-user
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)@$(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: check-non-root-user
+        - name: bundle
+          value: quay.io/foreman/tekton-catalog/task-check-non-root-user@sha256:92767a9910e4714bfda417cc018ea7c3a567299da212fab582156a33a4eb3c36
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: apply-tags
       params:
       - name: IMAGE_URL

--- a/.tekton/foreman-develop-pull-request.yaml
+++ b/.tekton/foreman-develop-pull-request.yaml
@@ -460,7 +460,9 @@ spec:
     - name: check-non-root-user
       params:
       - name: IMAGE_URL
-        value: $(tasks.build-image-index.results.IMAGE_URL)@$(tasks.build-image-index.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:
@@ -468,7 +470,7 @@ spec:
         - name: name
           value: check-non-root-user
         - name: bundle
-          value: quay.io/foreman/tekton-catalog/task-check-non-root-user@sha256:92767a9910e4714bfda417cc018ea7c3a567299da212fab582156a33a4eb3c36
+          value: quay.io/foreman/tekton-catalog/task-check-non-root-user@sha256:5d3b463691ade8dbb5fb25dc98b7dde3a97aea6e8f8b5e58c045ad34ed5ba08c
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/foreman-develop-pull-request.yaml
+++ b/.tekton/foreman-develop-pull-request.yaml
@@ -463,6 +463,8 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ALLOWED_USER
+        value: "994"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/foreman-develop-push.yaml
+++ b/.tekton/foreman-develop-push.yaml
@@ -456,7 +456,9 @@ spec:
     - name: check-non-root-user
       params:
       - name: IMAGE_URL
-        value: $(tasks.build-image-index.results.IMAGE_URL)@$(tasks.build-image-index.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:
@@ -464,7 +466,7 @@ spec:
         - name: name
           value: check-non-root-user
         - name: bundle
-          value: quay.io/foreman/tekton-catalog/task-check-non-root-user@sha256:92767a9910e4714bfda417cc018ea7c3a567299da212fab582156a33a4eb3c36
+          value: quay.io/foreman/tekton-catalog/task-check-non-root-user@sha256:5d3b463691ade8dbb5fb25dc98b7dde3a97aea6e8f8b5e58c045ad34ed5ba08c
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/foreman-develop-push.yaml
+++ b/.tekton/foreman-develop-push.yaml
@@ -453,6 +453,26 @@ spec:
         operator: in
         values:
         - "false"
+    - name: check-non-root-user
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)@$(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: check-non-root-user
+        - name: bundle
+          value: quay.io/foreman/tekton-catalog/task-check-non-root-user@sha256:92767a9910e4714bfda417cc018ea7c3a567299da212fab582156a33a4eb3c36
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: apply-tags
       params:
       - name: IMAGE_URL

--- a/.tekton/foreman-develop-push.yaml
+++ b/.tekton/foreman-develop-push.yaml
@@ -459,6 +459,8 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ALLOWED_USER
+        value: "994"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/foreman-proxy-develop-pull-request.yaml
+++ b/.tekton/foreman-proxy-develop-pull-request.yaml
@@ -463,6 +463,8 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ALLOWED_USER
+        value: "991"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/foreman-proxy-develop-pull-request.yaml
+++ b/.tekton/foreman-proxy-develop-pull-request.yaml
@@ -457,6 +457,26 @@ spec:
         operator: in
         values:
         - "false"
+    - name: check-non-root-user
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)@$(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: check-non-root-user
+        - name: bundle
+          value: quay.io/foreman/tekton-catalog/task-check-non-root-user@sha256:92767a9910e4714bfda417cc018ea7c3a567299da212fab582156a33a4eb3c36
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: apply-tags
       params:
       - name: IMAGE_URL

--- a/.tekton/foreman-proxy-develop-pull-request.yaml
+++ b/.tekton/foreman-proxy-develop-pull-request.yaml
@@ -460,7 +460,9 @@ spec:
     - name: check-non-root-user
       params:
       - name: IMAGE_URL
-        value: $(tasks.build-image-index.results.IMAGE_URL)@$(tasks.build-image-index.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:
@@ -468,7 +470,7 @@ spec:
         - name: name
           value: check-non-root-user
         - name: bundle
-          value: quay.io/foreman/tekton-catalog/task-check-non-root-user@sha256:92767a9910e4714bfda417cc018ea7c3a567299da212fab582156a33a4eb3c36
+          value: quay.io/foreman/tekton-catalog/task-check-non-root-user@sha256:5d3b463691ade8dbb5fb25dc98b7dde3a97aea6e8f8b5e58c045ad34ed5ba08c
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/foreman-proxy-develop-push.yaml
+++ b/.tekton/foreman-proxy-develop-push.yaml
@@ -459,6 +459,8 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ALLOWED_USER
+        value: "991"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/foreman-proxy-develop-push.yaml
+++ b/.tekton/foreman-proxy-develop-push.yaml
@@ -456,7 +456,9 @@ spec:
     - name: check-non-root-user
       params:
       - name: IMAGE_URL
-        value: $(tasks.build-image-index.results.IMAGE_URL)@$(tasks.build-image-index.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:
@@ -464,7 +466,7 @@ spec:
         - name: name
           value: check-non-root-user
         - name: bundle
-          value: quay.io/foreman/tekton-catalog/task-check-non-root-user@sha256:92767a9910e4714bfda417cc018ea7c3a567299da212fab582156a33a4eb3c36
+          value: quay.io/foreman/tekton-catalog/task-check-non-root-user@sha256:5d3b463691ade8dbb5fb25dc98b7dde3a97aea6e8f8b5e58c045ad34ed5ba08c
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/foreman-proxy-develop-push.yaml
+++ b/.tekton/foreman-proxy-develop-push.yaml
@@ -453,6 +453,26 @@ spec:
         operator: in
         values:
         - "false"
+    - name: check-non-root-user
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)@$(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: check-non-root-user
+        - name: bundle
+          value: quay.io/foreman/tekton-catalog/task-check-non-root-user@sha256:92767a9910e4714bfda417cc018ea7c3a567299da212fab582156a33a4eb3c36
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: apply-tags
       params:
       - name: IMAGE_URL


### PR DESCRIPTION
## Summary
- Add the `check-non-root-user` Tekton task (published in theforeman/theforeman-rel-eng-konflux#54) to all four pipeline definitions, running after `build-image-index` and gated by `skip-checks`, matching the pattern used for the other post-build checks.
- Follow-up from the review discussion on #70.

## Test plan
- [ ] Verify the pipeline runs succeed in Konflux for both `foreman` and `foreman-proxy` on push and pull-request events