### PR TITLE
Fix check-non-root-user ALLOWED_USER value

### DIFF
--- a/.tekton/foreman-develop-pull-request.yaml
+++ b/.tekton/foreman-develop-pull-request.yaml
@@ -464,7 +464,7 @@ spec:
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: ALLOWED_USER
-        value: "994"
+        value: "foreman"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/foreman-develop-push.yaml
+++ b/.tekton/foreman-develop-push.yaml
@@ -460,7 +460,7 @@ spec:
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: ALLOWED_USER
-        value: "994"
+        value: "foreman"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/foreman-proxy-develop-pull-request.yaml
+++ b/.tekton/foreman-proxy-develop-pull-request.yaml
@@ -464,7 +464,7 @@ spec:
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: ALLOWED_USER
-        value: "991"
+        value: "foreman-proxy"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/foreman-proxy-develop-push.yaml
+++ b/.tekton/foreman-proxy-develop-push.yaml
@@ -460,7 +460,7 @@ spec:
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: ALLOWED_USER
-        value: "991"
+        value: "foreman-proxy"
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
## Summary
Fixes the `check-non-root-user` failures on `develop` after #70 rebased (introduced in #75):
```
ERROR: Image user 'foreman' does not match required user '994'
ERROR: Image user 'foreman-proxy' does not match required user '991'
```

## Root cause
`ALLOWED_USER` was set to the numeric UID (`994`/`991`), but the OCI image config's `User` field stores the literal `USER` directive text from the Containerfile — and both Containerfiles use `USER foreman` / `USER foreman-proxy` (by name), not a numeric UID. Docker/OCI never resolves a named `USER` to a UID at build time; that only happens at container runtime via `/etc/passwd`. `skopeo inspect` (what the task uses) only sees build-time config, so it can never see the resolved numeric UID this way.

The numeric UID/GID being correct (994/994 for foreman, 991/991 for foreman-proxy) is already guaranteed by #70's `useradd -u 994`/`-u 991`, and independently verified by that PR's own new CI step (`podman run ... id -u foreman`).

## Fix
Set `ALLOWED_USER` to `"foreman"` / `"foreman-proxy"` to match what's actually in the image config. No Containerfile changes needed.

## Test plan
- [ ] `develop` pipeline passes `check-non-root-user` once this merges (after #70 is in)